### PR TITLE
feat(quiz): add dark mode toggle and year filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 
 # misc
 temp/
+docs/
+.agent/
 .DS_Store
 *.pem
 

--- a/app/components/ClientLayout.tsx
+++ b/app/components/ClientLayout.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { ThemeProvider } from "./ThemeProvider"
+
+export default function ClientLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider>
+      {children}
+    </ThemeProvider>
+  )
+}

--- a/app/components/LandingPage.tsx
+++ b/app/components/LandingPage.tsx
@@ -37,14 +37,16 @@ export default function LandingPage({
     }
 
     return "60"
-  })
-
+  })  
+  
   // Update selected year when prop changes
+
   useEffect(() => {
     setSelectedYear(propSelectedYear)
   }, [propSelectedYear])
 
-  // Calculate max questions based on selected year
+  
+// Calculate max questions based on year
   const maxQuestions = devModeYear 
     ? visualContentCount || 0
     : selectedYear === "all"

--- a/app/components/LandingPage.tsx
+++ b/app/components/LandingPage.tsx
@@ -1,28 +1,77 @@
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import Credits from "@/components/Credits"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Input } from "@/components/ui/input"
-import { quizData } from "@/assets/data"
+import { Calendar } from "lucide-react"
 
 interface LandingPageProps {
-  onStartQuiz: (numQuestions: number) => void
+  onStartQuiz: (numQuestions: number, selectedYear?: string) => void
   devModeYear?: number | null
   visualContentCount?: number
+  availableYears?: string[]
+  yearCounts?: Record<string, number>
+  yearRange?: string
+  selectedYear?: string
+  onYearChange?: (year: string) => void
 }
 
-export default function LandingPage({ onStartQuiz, devModeYear, visualContentCount }: LandingPageProps) {
+export default function LandingPage({ 
+  onStartQuiz, 
+  devModeYear, 
+  visualContentCount,
+  availableYears = [],
+  yearCounts = {},
+  yearRange = "",
+  selectedYear: propSelectedYear = "all",
+  onYearChange
+}: LandingPageProps) {
+  const [selectedYear, setSelectedYear] = useState(propSelectedYear)
   const [numQuestions, setNumQuestions] = useState(() => {
     if (typeof window !== "undefined") {
       const stored = parseInt(localStorage.getItem("numQuestions") || "60", 10)
-      return (isNaN(stored) || stored < 1 ? 60 : Math.min(stored, quizData.length)).toString()
+      const maxQuestions = selectedYear === "all" 
+        ? Object.values(yearCounts).reduce((sum, count) => sum + count, 0)
+        : yearCounts[selectedYear] || 60
+      return (isNaN(stored) || stored < 1 ? 60 : Math.min(stored, maxQuestions)).toString()
     }
 
     return "60"
   })
 
+  // Update selected year when prop changes
+  useEffect(() => {
+    setSelectedYear(propSelectedYear)
+  }, [propSelectedYear])
+
+  // Calculate max questions based on selected year
+  const maxQuestions = devModeYear 
+    ? visualContentCount || 0
+    : selectedYear === "all"
+    ? Object.values(yearCounts).reduce((sum, count) => sum + count, 0)
+    : yearCounts[selectedYear] || 0
+
+  const handleYearChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const year = e.target.value
+    setSelectedYear(year)
+    onYearChange?.(year)
+    
+    // Save to localStorage
+    if (typeof window !== "undefined") {
+      localStorage.setItem("selectedYear", year)
+    }
+
+    // Always default to maximum questions for selected year
+    const newMax = year === "all"
+      ? Object.values(yearCounts).reduce((sum, count) => sum + count, 0)
+      : yearCounts[year] || 0
+    
+    setNumQuestions(newMax.toString())
+  }
+
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNumQuestions((Math.max(1, Math.min(parseInt(e.target.value, 10), quizData.length))).toString())
+    const value = Math.max(1, Math.min(parseInt(e.target.value, 10), maxQuestions))
+    setNumQuestions(value.toString())
   }
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -32,7 +81,7 @@ export default function LandingPage({ onStartQuiz, devModeYear, visualContentCou
       localStorage.setItem("numQuestions", numQuestions)
     }
 
-    onStartQuiz(parseInt(numQuestions, 10))
+    onStartQuiz(parseInt(numQuestions, 10), selectedYear)
   }
 
   return (
@@ -52,36 +101,65 @@ export default function LandingPage({ onStartQuiz, devModeYear, visualContentCou
 
         <p>
           {devModeYear 
-            ? `Developer mode is active. Showing only ${devModeYear} questions with visual content (diagrams, choice images, or composite images). ${visualContentCount || 0} questions available for testing.`
-            : `This quiz contains randomly selected questions from a range of topics covered in previous years' exams. A total of ${quizData.length} questions are available.`
+            ? `Developer mode is active. Showing only ${devModeYear} questions with visual content (diagrams, choice  (${yearRange})images, or composite images). ${visualContentCount || 0} questions available for testing.`
+            : `This quiz contains randomly selected questions from a range of topics covered in previous years' exams. A total of ${Object.values(yearCounts).reduce((sum, count) => sum + count, 0)} questions are available.`
           }
         </p>
         <ul className="list-disc list-inside space-y-2">
-          <li>You are given a 1:30 minutes per questions</li>
+          <li>You are given 1:30 minutes per question</li>
           <li>Some questions may include images</li>
           <li>After completing the quiz, you&apos;ll receive detailed explanations for each question</li>
           <li>You can retake the quiz multiple times with different questions</li>
         </ul>
         <p>Are you ready to begin?</p>
         <Credits />
-        <form onSubmit={onSubmit} className="space-y-2">
-          {!devModeYear && <label htmlFor="numQuestions">Number of Questions</label>}
-          {devModeYear && <label htmlFor="numQuestions">Number of Questions (All Visual Content)</label>}
-          <div className="flex flex-col gap-2 w-full sm:flex-row">
-            <Input 
-              id="numQuestions" 
-              type="number" 
-              min={1} 
-              max={devModeYear ? visualContentCount : quizData.length} 
-              required 
-              value={devModeYear ? visualContentCount : numQuestions} 
-              onChange={onChange}
-              disabled={devModeYear ? true : false}
-              className={devModeYear ? "bg-muted cursor-not-allowed" : ""}
-            />
-              <Button className="w-full">
+        <form onSubmit={onSubmit} className="space-y-4">
+          {/* Year Filter */}
+          {!devModeYear && (
+            <div className="space-y-2">
+              <label htmlFor="yearFilter" className="flex items-center gap-2 text-sm font-medium">
+                <Calendar className="h-4 w-4" />
+                Year Filter
+              </label>
+              <select
+                id="yearFilter"
+                value={selectedYear}
+                onChange={handleYearChange}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <option value="all">
+                  All Years
+                </option>
+                {availableYears.map(year => (
+                  <option key={year} value={year}>
+                    {year}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Number of Questions */}
+          <div className="space-y-2">
+            <label htmlFor="numQuestions" className="text-sm font-medium">
+              {devModeYear ? "Number of Questions (All Visual Content)" : "Number of Questions"}
+            </label>
+            <div className="flex flex-col gap-2 w-full sm:flex-row">
+              <Input 
+                id="numQuestions" 
+                type="number" 
+                min={1} 
+                max={maxQuestions} 
+                required 
+                value={devModeYear ? visualContentCount : numQuestions} 
+                onChange={onChange}
+                disabled={!!devModeYear}
+                className={devModeYear ? "bg-muted cursor-not-allowed" : ""}
+              />
+              <Button type="submit" className="w-full sm:w-auto sm:min-w-[120px]">
                 Start Quiz
               </Button>
+            </div>
           </div>
         </form>
       </CardContent>

--- a/app/components/Markdown.tsx
+++ b/app/components/Markdown.tsx
@@ -50,7 +50,7 @@ const Markdown = ({children}: MarkdownProps) => {
         className='markdown'
         style={{
             background: 'none', 
-            color: 'black'
+            color: 'inherit'
         }}
         source={children}
         {...DEFAULT_PREVIEW_OPTIONS}

--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -17,13 +17,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     setMounted(true)
-    // Load theme from localStorage
     const savedTheme = localStorage.getItem("theme") as Theme | null
     if (savedTheme) {
       setTheme(savedTheme)
       document.documentElement.classList.toggle("dark", savedTheme === "dark")
     } else {
-      // Apply light mode on first load
       document.documentElement.classList.remove("dark")
     }
   }, [])

--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { createContext, useContext, useEffect, useState } from "react"
+
+type Theme = "light" | "dark"
+
+interface ThemeContextType {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light")
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    // Load theme from localStorage
+    const savedTheme = localStorage.getItem("theme") as Theme | null
+    if (savedTheme) {
+      setTheme(savedTheme)
+      document.documentElement.classList.toggle("dark", savedTheme === "dark")
+    } else {
+      // Apply light mode on first load
+      document.documentElement.classList.remove("dark")
+    }
+  }, [])
+
+  const toggleTheme = () => {
+    const newTheme = theme === "light" ? "dark" : "light"
+    setTheme(newTheme)
+    localStorage.setItem("theme", newTheme)
+    document.documentElement.classList.toggle("dark", newTheme === "dark")
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider")
+  }
+  return context
+}

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -13,7 +13,6 @@ export default function ThemeToggle() {
     setMounted(true)
   }, [])
 
-  // Prevent hydration mismatch by not rendering until client-side
   if (!mounted) {
     return (
       <Button

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { Moon, Sun } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useTheme } from "./ThemeProvider"
+import { useEffect, useState } from "react"
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Prevent hydration mismatch by not rendering until client-side
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-9 w-9 transition-all duration-200 hover:bg-primary-foreground/10"
+        aria-label="Toggle theme"
+        disabled
+      >
+        <Sun className="h-5 w-5" />
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      className="h-9 w-9 transition-all duration-200 hover:bg-primary-foreground/10 hover:scale-110"
+      aria-label="Toggle theme"
+    >
+      {theme === "light" ? (
+        <Moon className="h-5 w-5 transition-transform" />
+      ) : (
+        <Sun className="h-5 w-5 transition-transform" />
+      )}
+    </Button>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,11 +7,16 @@ body {
 }
 
 .markdown table th, td {
-  background-color: white;
+  background-color: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  border: 1px solid hsl(var(--border));
 }
 
 .markdown .code-highlight {
-  background-color: white;
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
 }
 
 .question {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import { Poppins } from "next/font/google";
 import "./globals.css";
 import HeaderLink from "./components/HeaderLink";
 import Footer from "./components/Footer";
+import ClientLayout from "./components/ClientLayout";
+import ThemeToggle from "./components/ThemeToggle";
 
 const poppins = Poppins({
   weight: ["400", "500", "600", "700"],
@@ -25,17 +27,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${poppins.variable} font-sans antialiased min-h-screen flex flex-col`}>
-        <header className="bg-primary text-primary-foreground px-6 py-4">
-          <div className="container mx-auto">
-            <HeaderLink />
-          </div>
-        </header>
-        <main className="flex-1 p-4 md:px-6">
-          {children}
-        </main>
-        <Footer />
+        <ClientLayout>
+          <>
+            <header className="bg-primary text-primary-foreground px-6 py-4">
+              <div className="container mx-auto flex items-center justify-between">
+                <HeaderLink />
+                <ThemeToggle />
+              </div>
+            </header>
+            <main className="flex-1 p-4 md:px-6">
+              {children}
+            </main>
+            <Footer />
+          </>
+        </ClientLayout>
       </body>
     </html>
   );

--- a/app/lib/yearFilter.ts
+++ b/app/lib/yearFilter.ts
@@ -6,30 +6,18 @@ import _2021 from '@/assets/data/2021/index.json'
 import _2020 from '@/assets/data/2020/index.json'
 import _2019 from '@/assets/data/2019/index.json'
 
-/**
- * Get available years based on imported data files
- * Returns array of years sorted in descending order (newest first)
- */
 export function getAvailableYears(): string[] {
   return ['2025', '2024', '2023', '2022', '2021', '2020', '2019']
 }
 
-/**
- * Get year range for display (e.g., "2019-2025")
- * Returns string showing earliest to latest year
- */
 export function getYearRange(): string {
   const years = getAvailableYears()
   if (years.length === 0) return ''
-  const oldest = years[years.length - 1] // Last in desc array
-  const newest = years[0] // First in desc array
+  const oldest = years[years.length - 1]
+  const newest = years[0]
   return `${oldest}-${newest}`
 }
 
-/**
- * Get question count for each year
- * Returns object with year as key and count as value
- */
 export function getYearCounts(): Record<string, number> {
   return {
     '2025': _2025.length,
@@ -42,13 +30,6 @@ export function getYearCounts(): Record<string, number> {
   }
 }
 
-/**
- * Filter questions by year
- * Uses folder structure to map to correct data
- * 
- * @param year - Year to filter by, or 'all' for all years
- * @returns Filtered array of questions
- */
 export function filterQuestionsByYear(year: string) {
   if (year === 'all') {
     return [..._2025, ..._2024, ..._2023, ..._2022, ..._2021, ..._2020, ..._2019]

--- a/app/lib/yearFilter.ts
+++ b/app/lib/yearFilter.ts
@@ -1,0 +1,68 @@
+import _2025 from '@/assets/data/2025/index.json'
+import _2024 from '@/assets/data/2024/index.json'
+import _2023 from '@/assets/data/2023/index.json'
+import _2022 from '@/assets/data/2022/index.json'
+import _2021 from '@/assets/data/2021/index.json'
+import _2020 from '@/assets/data/2020/index.json'
+import _2019 from '@/assets/data/2019/index.json'
+
+/**
+ * Get available years based on imported data files
+ * Returns array of years sorted in descending order (newest first)
+ */
+export function getAvailableYears(): string[] {
+  return ['2025', '2024', '2023', '2022', '2021', '2020', '2019']
+}
+
+/**
+ * Get year range for display (e.g., "2019-2025")
+ * Returns string showing earliest to latest year
+ */
+export function getYearRange(): string {
+  const years = getAvailableYears()
+  if (years.length === 0) return ''
+  const oldest = years[years.length - 1] // Last in desc array
+  const newest = years[0] // First in desc array
+  return `${oldest}-${newest}`
+}
+
+/**
+ * Get question count for each year
+ * Returns object with year as key and count as value
+ */
+export function getYearCounts(): Record<string, number> {
+  return {
+    '2025': _2025.length,
+    '2024': _2024.length,
+    '2023': _2023.length,
+    '2022': _2022.length,
+    '2021': _2021.length,
+    '2020': _2020.length,
+    '2019': _2019.length,
+  }
+}
+
+/**
+ * Filter questions by year
+ * Uses folder structure to map to correct data
+ * 
+ * @param year - Year to filter by, or 'all' for all years
+ * @returns Filtered array of questions
+ */
+export function filterQuestionsByYear(year: string) {
+  if (year === 'all') {
+    return [..._2025, ..._2024, ..._2023, ..._2022, ..._2021, ..._2020, ..._2019]
+  }
+  
+  const yearDataMap: Record<string, any[]> = {
+    '2025': _2025,
+    '2024': _2024,
+    '2023': _2023,
+    '2022': _2022,
+    '2021': _2021,
+    '2020': _2020,
+    '2019': _2019,
+  }
+  
+  return [...(yearDataMap[year] || [])]
+}

--- a/scripts/PIPELINE_USAGE.md
+++ b/scripts/PIPELINE_USAGE.md
@@ -139,22 +139,62 @@ After Phase 2 completes, update the web app:
 1. **Import the new year** in `app/assets/data/index.ts`:
 
    ```typescript
-   import _2025 from '@/assets/data/2025/index.json'
+   import _2026 from '@/assets/data/2026/index.json'
    ```
+
 2. **Add to quizData array**:
 
    ```typescript
    export const quizData: QuizQuestion[] = [
+     ..._2026,  // Add newest year first
      ..._2025,
      ..._2024,
      // ... other years
    ]
    ```
-3. **Test**:
+
+3. **Update year filter** in `app/lib/yearFilter.ts`:
+
+   ```typescript
+   export function getAvailableYears(): string[] {
+     return ['2026', '2025', '2024', '2023', '2022', '2021', '2020', '2019']
+   }
+
+   export function getYearCounts(): Record<string, number> {
+     return {
+       '2026': _2026.length,  // Add this line
+       '2025': _2025.length,
+       // ... rest
+     }
+   }
+
+   export function filterQuestionsByYear(year: string) {
+     if (year === 'all') {
+       return [..._2026, ..._2025, ...]  // Add _2026 here
+     }
+     
+     const yearDataMap: Record<string, any[]> = {
+       '2026': _2026,  // Add this line
+       '2025': _2025,
+       // ... rest
+     }
+   }
+   ```
+
+   **Don't forget to import** at the top of `yearFilter.ts`:
+   ```typescript
+   import _2026 from '@/assets/data/2026/index.json'
+   ```
+
+4. **Test**:
 
    ```bash
    npm run dev
    ```
+
+   - Check landing page shows updated year range (e.g., "2019-2026")
+   - Verify year dropdown includes 2026
+   - Test filtering by selecting 2026
 
 ---
 


### PR DESCRIPTION
Implements three major UI enhancements cuz why not (?):


1. Dark Mode Toggle
   - Added toggle button with Moon/Sun icons
   - localStorage persistence across sessions
   - Light mode default

2. Year Filter Dropdown
   - Select specific years (2019-2025) or "All Years"
   - Auto-resets question count to year maximum
   - Calendar icon for visual clarity
   - Disabled in dev mode (?dev=YYYY)

3. Dynamic Year Detection
   - Auto-detects available years from data imports
   - Shows year range in description (e.g., "2019-2025")
   - Question counts calculated per year
   - Updates automatically when new years are added
