### PR TITLE
feat: implement answer choice shuffling to prevent correct answers position memorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,12 +20,6 @@
 # production
 /build
 
-# misc
-temp/
-docs/
-.agent/
-.DS_Store
-*.pem
 
 # debug
 npm-debug.log*
@@ -42,3 +36,10 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# misc
+temp/
+docs/
+.agent/
+.DS_Store
+*.pem

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This repository hosts an online PhilNITS FE AM Mock Examination, developed using
 - After completing the quiz, you'll receive **detailed explanations** for each question.
 - You can **retake the quiz multiple times**, with different sets of questions.
 
-## 🔧 Content Management Pipeline (By Homer Adriel Dorin)
+## 🔧 Content Management Pipeline
+
+By Homer Adriel Dorin
 
 This project includes a unified pipeline for extracting exam questions from PDFs and converting them into web-ready JSON format.
 
@@ -50,6 +52,7 @@ For detailed pipeline documentation, see PIPELINE_USAGE.md under scripts/ for mo
    git clone https://github.com/usc-cisco/philnits-mock.git
    cd philnits-mock
    ```
+
 2. **Install dependencies:**
 
    ```sh
@@ -57,6 +60,7 @@ For detailed pipeline documentation, see PIPELINE_USAGE.md under scripts/ for mo
    # or
    yarn install
    ```
+
 3. **Start the development server:**
 
    ```sh
@@ -64,6 +68,7 @@ For detailed pipeline documentation, see PIPELINE_USAGE.md under scripts/ for mo
    # or
    yarn dev
    ```
+
 4. Open [http://localhost:3000](http://localhost:3000) in your web browser.
 
 ## Contributing

--- a/app/lib/shuffle.ts
+++ b/app/lib/shuffle.ts
@@ -4,10 +4,6 @@
  * Provides deterministic shuffling of answer choices based on question ID.
  */
 
-/**
- * @param seed - String to use as seed (typically question ID)
- * @returns Random number between 0 and 1
- */
 function seededRandom(seed: string): () => number {
   let hash = 0;
   for (let i = 0; i < seed.length; i++) {
@@ -26,8 +22,6 @@ function seededRandom(seed: string): () => number {
 
 /**
  * Fisher-Yates shuffle algorithm with seeded randomization
- * @param array - Array to shuffle
- * @param seed - Seed string for deterministic shuffling
  * @returns New shuffled array (does not mutate original)
  */
 export function shuffleArray<T>(array: T[], seed: string): T[] {
@@ -44,10 +38,6 @@ export function shuffleArray<T>(array: T[], seed: string): T[] {
 
 /**
  * Shuffle answer choices and update the correct answer index
- * @param options - Array of answer choice strings
- * @param correctAnswer - Original index of correct answer (0-indexed)
- * @param questionId - Unique question identifier for seeding
- * @returns Object with shuffled options and new correct answer index
  */
 export function shuffleChoices(
   options: string[],
@@ -71,15 +61,12 @@ export function shuffleChoices(
 }
 
 /**
- * Determine if a question should have its choices shuffled
  * Questions with visual content (images for choices or composite images) should not be shuffled
- * @param question - Quiz question object
  * @returns true if question should be shuffled, false otherwise
  */
 export function shouldShuffleQuestion(question: {
   choiceImage?: string;
   compositeImage?: string;
 }): boolean {
-  // Don't shuffle if question has choice images or composite images
   return !question.choiceImage && !question.compositeImage;
 }

--- a/app/lib/shuffle.ts
+++ b/app/lib/shuffle.ts
@@ -1,0 +1,85 @@
+/**
+ * Shuffle Utility for Quiz Answer Choices
+ *
+ * Provides deterministic shuffling of answer choices based on question ID.
+ */
+
+/**
+ * @param seed - String to use as seed (typically question ID)
+ * @returns Random number between 0 and 1
+ */
+function seededRandom(seed: string): () => number {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    const char = seed.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+
+  // LCG
+  let state = Math.abs(hash);
+  return function () {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
+/**
+ * Fisher-Yates shuffle algorithm with seeded randomization
+ * @param array - Array to shuffle
+ * @param seed - Seed string for deterministic shuffling
+ * @returns New shuffled array (does not mutate original)
+ */
+export function shuffleArray<T>(array: T[], seed: string): T[] {
+  const shuffled = [...array];
+  const random = seededRandom(seed);
+
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  return shuffled;
+}
+
+/**
+ * Shuffle answer choices and update the correct answer index
+ * @param options - Array of answer choice strings
+ * @param correctAnswer - Original index of correct answer (0-indexed)
+ * @param questionId - Unique question identifier for seeding
+ * @returns Object with shuffled options and new correct answer index
+ */
+export function shuffleChoices(
+  options: string[],
+  correctAnswer: number,
+  questionId: string,
+): { shuffledOptions: string[]; shuffledCorrectAnswer: number } {
+  // Create mapping of original indices to shuffled indices
+  const indices = options.map((_, i) => i);
+  const shuffledIndices = shuffleArray(indices, questionId);
+
+  // Shuffle the options using the same mapping
+  const shuffledOptions = shuffledIndices.map((i) => options[i]);
+
+  // Find where the correct answer moved to
+  const shuffledCorrectAnswer = shuffledIndices.indexOf(correctAnswer);
+
+  return {
+    shuffledOptions,
+    shuffledCorrectAnswer,
+  };
+}
+
+/**
+ * Determine if a question should have its choices shuffled
+ * Questions with visual content (images for choices or composite images) should not be shuffled
+ * @param question - Quiz question object
+ * @returns true if question should be shuffled, false otherwise
+ */
+export function shouldShuffleQuestion(question: {
+  choiceImage?: string;
+  compositeImage?: string;
+}): boolean {
+  // Don't shuffle if question has choice images or composite images
+  return !question.choiceImage && !question.compositeImage;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -121,7 +121,7 @@ export default function Quiz() {
             q.id,
           );
 
-          // Debug logging - only in dev mode
+          // only in dev mode
           if (process.env.NODE_ENV === "development" || devModeYear) {
             console.log(`Shuffled ${q.id}:`);
             console.log(
@@ -139,7 +139,7 @@ export default function Quiz() {
             correctAnswer: shuffledCorrectAnswer,
           };
         }
-        // Keep original order for questions with visual content
+        // Keep original order for questions with visuals
         if (process.env.NODE_ENV === "development" || devModeYear) {
           console.log(`⏭Skipped shuffling ${q.id} (has visual content)`);
         }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,177 +1,244 @@
-"use client"
+"use client";
 
-import { useState, useEffect, useCallback } from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { Button } from "@/components/ui/button"
-import Question from "@/components/Question"
-import Results from "@/components/Results"
-import Timer from "@/components/Timer"
-import LandingPage from "@/components/LandingPage"
-import { quizData, type QuizQuestion } from "@/assets/data"
-import { getAvailableYears, getYearCounts, filterQuestionsByYear, getYearRange } from "@/lib/yearFilter" 
+import { useState, useEffect, useCallback } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import Question from "@/components/Question";
+import Results from "@/components/Results";
+import Timer from "@/components/Timer";
+import LandingPage from "@/components/LandingPage";
+import { quizData, type QuizQuestion } from "@/assets/data";
+import {
+  getAvailableYears,
+  getYearCounts,
+  filterQuestionsByYear,
+  getYearRange,
+} from "@/lib/yearFilter";
+import { shuffleChoices, shouldShuffleQuestion } from "@/lib/shuffle";
 
 // Developer Mode - For Testing Visual Content
 // Enable via URL parameter: ?dev=2025 (or any year)
 // Filters to show only visual content questions from that year
 const getDevModeYear = (): number | null => {
-  if (typeof window === 'undefined') return null
-  
-  const urlParams = new URLSearchParams(window.location.search)
-  const devParam = urlParams.get('dev')
-  
+  if (typeof window === "undefined") return null;
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const devParam = urlParams.get("dev");
+
   if (devParam) {
-    const year = parseInt(devParam, 10)
-    return !isNaN(year) ? year : null
+    const year = parseInt(devParam, 10);
+    return !isNaN(year) ? year : null;
   }
-  
-  return null
-}
+
+  return null;
+};
 
 export default function Quiz() {
-  const [questions, setQuestions] = useState<QuizQuestion[]>([])
-  const [currentQuestion, setCurrentQuestion] = useState(0)
-  const [userAnswers, setUserAnswers] = useState<number[]>([])
-  const [quizStarted, setQuizStarted] = useState(false)
-  const [quizCompleted, setQuizCompleted] = useState(false)
-  const [totalTime, setTotalTime] = useState(0)
-  const [timeRemaining, setTimeRemaining] = useState(0)
-  const [devModeYear, setDevModeYear] = useState<number | null>(null)
-  const [showSubmitDialog, setShowSubmitDialog] = useState(false)
-  const [selectedYear, setSelectedYear] = useState<string>("all")
+  const [questions, setQuestions] = useState<QuizQuestion[]>([]);
+  const [currentQuestion, setCurrentQuestion] = useState(0);
+  const [userAnswers, setUserAnswers] = useState<number[]>([]);
+  const [quizStarted, setQuizStarted] = useState(false);
+  const [quizCompleted, setQuizCompleted] = useState(false);
+  const [totalTime, setTotalTime] = useState(0);
+  const [timeRemaining, setTimeRemaining] = useState(0);
+  const [devModeYear, setDevModeYear] = useState<number | null>(null);
+  const [showSubmitDialog, setShowSubmitDialog] = useState(false);
+  const [selectedYear, setSelectedYear] = useState<string>("all");
 
-  // Initialize dev mode on mount
   useEffect(() => {
-    setDevModeYear(getDevModeYear())
-    // Load selected year from localStorage
-    const savedYear = localStorage.getItem("selectedYear")
+    setDevModeYear(getDevModeYear());
+    const savedYear = localStorage.getItem("selectedYear");
     if (savedYear) {
-      setSelectedYear(savedYear)
+      setSelectedYear(savedYear);
     }
-  }, [])
+  }, []);
 
-  const shuffle = (array: QuizQuestion[]) => { 
-    for (let i = array.length - 1; i > 0; i--) { 
-      const j = Math.floor(Math.random() * (i + 1)); 
-      [array[i], array[j]] = [array[j], array[i]]; 
-    } 
-    return array; 
+  const shuffle = (array: QuizQuestion[]) => {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
   };
 
-  const startQuiz = useCallback((numQuestions: number, year?: string) => {
-    let questionsToUse: QuizQuestion[]
-    
-    if (devModeYear) {
-      // Developer mode: Load ONLY questions from specified year with visual content
-      // For testing diagram injection and visual content validation
-      const yearQuestions = quizData.filter(q => q.id.startsWith(`${devModeYear}_FE-A`))
-      const visualQuestions = yearQuestions.filter(q => 
-        q.choiceImage || 
-        q.compositeImage || 
-        q.question.includes('![Image](')
-      )
-      questionsToUse = visualQuestions
-      console.log(`DEV MODE: Loaded ${visualQuestions.length} visual content questions from ${devModeYear}`)
-      console.log('Question IDs:', visualQuestions.map(q => q.id.replace(`${devModeYear}_FE-A_`, 'Q')).join(', '))
-    } else {
-      // Normal mode: Filter by year, then shuffle
-      const yearToUse = year || selectedYear
-      const filteredByYear = filterQuestionsByYear(yearToUse)
-      const shuffled = shuffle([...filteredByYear])
-      questionsToUse = shuffled.slice(0, numQuestions)
-      console.log(`Loaded ${questionsToUse.length} questions from ${yearToUse === 'all' ? 'all years' : yearToUse}`)
-    }
-    
-    setQuestions(questionsToUse)
-    setQuizStarted(true)
+  const startQuiz = useCallback(
+    (numQuestions: number, year?: string) => {
+      let questionsToUse: QuizQuestion[];
 
-    const totalTime = questionsToUse.length * 90 * 1000
+      if (devModeYear) {
+        // Developer mode: Load ONLY questions from specified year with visual content
+        // For testing diagram injection and visual content validation
+        const yearQuestions = quizData.filter((q) =>
+          q.id.startsWith(`${devModeYear}_FE-A`),
+        );
+        const visualQuestions = yearQuestions.filter(
+          (q) =>
+            q.choiceImage ||
+            q.compositeImage ||
+            q.question.includes("![Image]("),
+        );
+        questionsToUse = visualQuestions;
+        console.log(
+          `DEV MODE: Loaded ${visualQuestions.length} visual content questions from ${devModeYear}`,
+        );
+        console.log(
+          "Question IDs:",
+          visualQuestions
+            .map((q) => q.id.replace(`${devModeYear}_FE-A_`, "Q"))
+            .join(", "),
+        );
+      } else {
+        // Normal mode: Filter by year, then shuffle
+        const yearToUse = year || selectedYear;
+        const filteredByYear = filterQuestionsByYear(yearToUse);
+        const shuffled = shuffle([...filteredByYear]);
+        questionsToUse = shuffled.slice(0, numQuestions);
+        console.log(
+          `Loaded ${questionsToUse.length} questions from ${yearToUse === "all" ? "all years" : yearToUse}`,
+        );
+      }
 
-    setTotalTime(totalTime)
-    setTimeRemaining(totalTime)
-  }, [devModeYear, selectedYear])
+      const processedQuestions = questionsToUse.map((q) => {
+        if (shouldShuffleQuestion(q)) {
+          // Shuffle choices for text-based questions
+          const { shuffledOptions, shuffledCorrectAnswer } = shuffleChoices(
+            q.options,
+            q.correctAnswer,
+            q.id,
+          );
+
+          // Debug logging - only in dev mode
+          if (process.env.NODE_ENV === "development" || devModeYear) {
+            console.log(`Shuffled ${q.id}:`);
+            console.log(
+              `Original correct: ${String.fromCharCode(65 + q.correctAnswer)} → Shuffled: ${String.fromCharCode(65 + shuffledCorrectAnswer)}`,
+            );
+            console.log(`Original A: "${q.options[0].substring(0, 30)}..."`);
+            console.log(
+              `Shuffled A: "${shuffledOptions[0].substring(0, 30)}..."`,
+            );
+          }
+
+          return {
+            ...q,
+            options: shuffledOptions,
+            correctAnswer: shuffledCorrectAnswer,
+          };
+        }
+        // Keep original order for questions with visual content
+        if (process.env.NODE_ENV === "development" || devModeYear) {
+          console.log(`⏭Skipped shuffling ${q.id} (has visual content)`);
+        }
+        return q;
+      });
+
+      setQuestions(processedQuestions);
+      setQuizStarted(true);
+
+      const totalTime = processedQuestions.length * 90 * 1000;
+
+      setTotalTime(totalTime);
+      setTimeRemaining(totalTime);
+    },
+    [devModeYear, selectedYear],
+  );
 
   const endQuiz = useCallback(() => {
-    setQuizCompleted(true)
-  }, [])
+    setQuizCompleted(true);
+  }, []);
 
   useEffect(() => {
-    let timer: NodeJS.Timeout
+    let timer: NodeJS.Timeout;
     if (quizStarted && !quizCompleted) {
       timer = setInterval(() => {
         setTimeRemaining((prevTime) => {
           if (prevTime <= 1000) {
-            clearInterval(timer)
-            endQuiz()
-            return 0
+            clearInterval(timer);
+            endQuiz();
+            return 0;
           }
-          return prevTime - 1000
-        })
-      }, 1000)
+          return prevTime - 1000;
+        });
+      }, 1000);
     }
 
-    return () => clearInterval(timer)
-  }, [quizStarted, quizCompleted, endQuiz])
+    return () => clearInterval(timer);
+  }, [quizStarted, quizCompleted, endQuiz]);
 
   const handleAnswer = (selectedOption: number) => {
-    const newUserAnswers = [...userAnswers]
-    newUserAnswers[currentQuestion] = selectedOption
-    setUserAnswers(newUserAnswers)
+    const newUserAnswers = [...userAnswers];
+    newUserAnswers[currentQuestion] = selectedOption;
+    setUserAnswers(newUserAnswers);
 
     if (currentQuestion < questions.length - 1) {
-      setCurrentQuestion(currentQuestion + 1)
+      setCurrentQuestion(currentQuestion + 1);
     } else {
-      endQuiz()
+      endQuiz();
     }
-  }
+  };
 
   const handleGoBack = () => {
     if (currentQuestion > 0) {
-      setCurrentQuestion(currentQuestion - 1)
+      setCurrentQuestion(currentQuestion - 1);
     }
-  }
+  };
 
   const handleSubmit = () => {
-    setShowSubmitDialog(true)
-  }
+    setShowSubmitDialog(true);
+  };
 
   const confirmSubmit = () => {
-    setShowSubmitDialog(false)
-    endQuiz()
-  }
+    setShowSubmitDialog(false);
+    endQuiz();
+  };
 
   const restartQuiz = () => {
-    setUserAnswers([])
-    setQuizStarted(true)
-    setQuizCompleted(false)
-    setTimeRemaining(totalTime)
-    setCurrentQuestion(0)
-  }
+    setUserAnswers([]);
+    setQuizStarted(true);
+    setQuizCompleted(false);
+    setTimeRemaining(totalTime);
+    setCurrentQuestion(0);
+  };
 
   const newQuiz = () => {
-    setUserAnswers([])
-    setQuizStarted(false)
-    setQuizCompleted(false)
-    setTimeRemaining(totalTime)
-    setCurrentQuestion(0)
-  }
+    setUserAnswers([]);
+    setQuizStarted(false);
+    setQuizCompleted(false);
+    setTimeRemaining(totalTime);
+    setCurrentQuestion(0);
+  };
 
   // Calculate visual content count for dev mode
   const getVisualContentCount = () => {
-    if (!devModeYear) return 0
-    const yearQuestions = quizData.filter(q => q.id.startsWith(`${devModeYear}_FE-A`))
-    return yearQuestions.filter(q => 
-      q.choiceImage || 
-      q.compositeImage || 
-      q.question.includes('![Image](')
-    ).length
-  }
+    if (!devModeYear) return 0;
+    const yearQuestions = quizData.filter((q) =>
+      q.id.startsWith(`${devModeYear}_FE-A`),
+    );
+    return yearQuestions.filter(
+      (q) =>
+        q.choiceImage || q.compositeImage || q.question.includes("![Image]("),
+    ).length;
+  };
 
   return (
     <div className="container mx-auto p-4">
       {!quizStarted ? (
-        <LandingPage 
-          onStartQuiz={startQuiz} 
+        <LandingPage
+          onStartQuiz={startQuiz}
           devModeYear={devModeYear}
           visualContentCount={getVisualContentCount()}
           availableYears={getAvailableYears()}
@@ -184,13 +251,17 @@ export default function Quiz() {
         <Card className="w-full max-w-2xl mx-auto">
           <CardHeader>
             <CardTitle>
-              Exam Review Quiz {devModeYear && <span className="text-sm text-warning ml-2">(Dev Mode: {devModeYear})</span>}
+              Exam Review Quiz{" "}
+              {devModeYear && (
+                <span className="text-sm text-warning ml-2">
+                  (Dev Mode: {devModeYear})
+                </span>
+              )}
             </CardTitle>
             <CardDescription>
-              {devModeYear 
-                ? `Developer Mode: Testing ${devModeYear} visual content questions only` 
-                : "Test your knowledge and review explanations"
-              }
+              {devModeYear
+                ? `Developer Mode: Testing ${devModeYear} visual content questions only`
+                : "Test your knowledge and review explanations"}
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -228,20 +299,21 @@ export default function Quiz() {
           <DialogHeader>
             <DialogTitle>Submit Quiz Early?</DialogTitle>
             <DialogDescription>
-              Are you sure you want to submit your quiz? You still have time remaining.
+              Are you sure you want to submit your quiz? You still have time
+              remaining.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="gap-2 sm:gap-0">
-            <Button variant="outline" onClick={() => setShowSubmitDialog(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setShowSubmitDialog(false)}
+            >
               Cancel
             </Button>
-            <Button onClick={confirmSubmit}>
-              Yes, Submit
-            </Button>
+            <Button onClick={confirmSubmit}>Yes, Submit</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>
-  )
+  );
 }
-


### PR DESCRIPTION
Add seeded shuffling of answer choices for text-based quiz questions to
discourage students from memorizing answer positions instead of actually reading the choices

Changes:
- Add shuffle utility (app/lib/shuffle.ts) with seeded Fisher-Yates algorithm and Linear Congruential Generator for deterministic randomization
- Update quiz logic to shuffle choices for text-based questions only
- Preserve original order for questions with visual content (choiceImage,
  compositeImage) where position matters
- Use question ID as seed for consistent shuffle within quiz session
- Add dev-mode-only logging for shuffle validation
